### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,17 +1,17 @@
 # Datatypes (KEYWORD1)
-Nanoshield_ADC12 KEYWORD1
-Nanoshield_ADC16 KEYWORD1
+Nanoshield_ADC12	KEYWORD1
+Nanoshield_ADC16	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-writeRegister KEYWORD2
-readRegister KEYWORD2
-begin KEYWORD2
-readADC_SingleEnded KEYWORD2
-readADC_Differential_0_1 KEYWORD2
-readADC_Differential_2_3 KEYWORD2
-startComparator_SingleEnded KEYWORD2
-getLastConversionResults KEYWORD2
-setGain KEYWORD2
-getGain KEYWORD2
+writeRegister	KEYWORD2
+readRegister	KEYWORD2
+begin	KEYWORD2
+readADC_SingleEnded	KEYWORD2
+readADC_Differential_0_1	KEYWORD2
+readADC_Differential_2_3	KEYWORD2
+startComparator_SingleEnded	KEYWORD2
+getLastConversionResults	KEYWORD2
+setGain	KEYWORD2
+getGain	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords